### PR TITLE
Edit task

### DIFF
--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
 import { Task, TaskItemProps } from './TodoList.interface';
 
@@ -11,6 +11,14 @@ const check = '\u2713';
 export default function TaskItem(props: TaskItemProps) {
   const { task, toggleComplete, removeTask, toggleEditOn, handleChange } = props;
 
+  // TODO: see how to trigger toggleEdit on input blur without preventing other UI interaction
+  // TODO: move to higher component, only one possible input open at once
+  const activeInput = useRef<HTMLInputElement>(null);
+  
+  useEffect(() => {
+    activeInput.current?.focus()
+  }, [activeInput, task.editOn])
+  
   const getCompleteClass = (task: Task) => (task.completed ? 'complete' : '');
 
   return (
@@ -20,7 +28,12 @@ export default function TaskItem(props: TaskItemProps) {
           {task.completed ? xBox : box}
         </span>
         {task.editOn ?
-          <input type='text' value={task.text} onChange={handleChange(task.id)}/> // TODO: Fix size issue
+          <input 
+            type='text' 
+            value={task.text} 
+            onChange={handleChange(task.id)} 
+            ref={activeInput}
+          /> // TODO: Fix size issue
         : <span className={`item-text ${getCompleteClass(task)}`}>
             {task.text}
           </span>

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -4,6 +4,9 @@ import { Task, TaskItemProps } from './TodoList.interface';
 
 const box = '\u2610';
 const xBox = '\u2612';
+const x = '\u2715';
+const pencil = '\u270F';
+const check = '\u2713';
 
 export default function TaskItem(props: TaskItemProps) {
   const { task, toggleComplete, removeTask } = props;
@@ -20,7 +23,13 @@ export default function TaskItem(props: TaskItemProps) {
           {task.text}
         </span>
       </div>
-      <button onClick={() => removeTask(task.id)}>Remove</button>
+      <div className='todo-item-buttons'>
+        {task.editOn ?
+          <span className='check'>{check}</span>
+        : <span className='pencil'>{pencil}</span>
+        }
+        <span className='x-remove' onClick={() => removeTask(task.id)}>{x}</span>
+      </div>
     </div>
   );
 }

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -27,17 +27,15 @@ export default function TaskItem(props: TaskItemProps) {
         <span className='checkbox' onClick={() => toggleComplete(task.id)}>
           {task.completed ? xBox : box}
         </span>
-        {task.editOn ?
-          <input 
-            type='text' 
-            value={task.text} 
-            onChange={handleChange(task.id)} 
-            ref={activeInput}
-          /> // TODO: Fix size issue
-        : <span className={`item-text ${getCompleteClass(task)}`}>
-            {task.text}
-          </span>
-        }
+        <input
+          type='text'
+          value={task.text}
+          onChange={handleChange(task.id)}
+          ref={activeInput}
+          className={`item-text ${getCompleteClass(task)}`}
+          style={{width: task.text.length + 2 + 'ch'}} // TODO: move to css component library
+          readOnly={!task.editOn}
+        />
       </div>
       <div className='todo-item-buttons'>
         {task.editOn ?

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -19,8 +19,10 @@ export default function TaskItem(props: TaskItemProps) {
   
   const getCompleteClass = (task: Task) => (task.completed ? 'complete' : '');
 
+  const getEditOnClass = (task: Task) => (task.editOn ? 'edit' : '');
+
   return (
-    <div className={`item-line ${getCompleteClass(task)}`}>
+    <div className={`item-line ${getCompleteClass(task)} ${getEditOnClass(task)}`}>
       <div className='todo-item'>
         <span className='checkbox' onClick={() => toggleComplete(task.id)}>
           {task.completed ? xBox : box}
@@ -39,8 +41,9 @@ export default function TaskItem(props: TaskItemProps) {
         </form>
       </div>
       <div className='todo-item-buttons'>
-        {!task.editOn &&
-          <span className='pencil' onClick={() => toggleEditOn(task.id)}>{pencil}</span>
+        {task.editOn ?
+          <span className='no-pencil'></span>
+        : <span className='pencil' onClick={() => toggleEditOn(task.id)}>{pencil}</span>
         }
         <span className='x-remove' onClick={() => removeTask(task.id)}>{x}</span>
       </div>

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -19,13 +19,16 @@ export default function TaskItem(props: TaskItemProps) {
         <span className='checkbox' onClick={() => {toggleComplete(task.id)}}>
           {task.completed ? xBox : box}
         </span>
-        <span className={`item-text ${getCompleteClass(task)}`}>
-          {task.text}
-        </span>
+        {task.editOn ?
+          <input type='text' value={task.text}></input> // TODO: Fix size issue
+        : <span className={`item-text ${getCompleteClass(task)}`}>
+            {task.text}
+          </span>
+        }
       </div>
       <div className='todo-item-buttons'>
         {task.editOn ?
-          <span className='check'>{check}</span>
+          <span className='check'>{check}</span> // TODO: Fix width/weight difference
         : <span className='pencil'>{pencil}</span>
         }
         <span className='x-remove' onClick={() => removeTask(task.id)}>{x}</span>

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -6,12 +6,10 @@ const box = '\u2610';
 const xBox = '\u2612';
 const x = '\u2715';
 const pencil = '\u270F';
-const check = '\u2713';
 
 export default function TaskItem(props: TaskItemProps) {
-  const { task, toggleComplete, removeTask, toggleEditOn, handleChange } = props;
+  const { task, toggleComplete, removeTask, toggleEditOn, handleChange, handleSubmit } = props;
 
-  // TODO: see how to trigger toggleEdit on input blur without preventing other UI interaction
   // TODO: move to higher component, only one possible input open at once
   const activeInput = useRef<HTMLInputElement>(null);
   
@@ -27,20 +25,22 @@ export default function TaskItem(props: TaskItemProps) {
         <span className='checkbox' onClick={() => toggleComplete(task.id)}>
           {task.completed ? xBox : box}
         </span>
-        <input
-          type='text'
-          value={task.text}
-          onChange={handleChange(task.id)}
-          ref={activeInput}
-          className={`item-text ${getCompleteClass(task)}`}
-          style={{width: task.text.length + 2 + 'ch'}} // TODO: move to css component library
-          readOnly={!task.editOn}
-        />
+        <form onSubmit={handleSubmit(task.id)}>
+          <input
+            type='text'
+            value={task.text}
+            onChange={handleChange(task.id)}
+            ref={activeInput}
+            className={`item-text ${getCompleteClass(task)}`}
+            style={{width: task.text.length + 2 + 'ch'}} // TODO: move to css component library
+            readOnly={!task.editOn}
+            onBlur={() => task.editOn && toggleEditOn(task.id)}
+          />
+        </form>
       </div>
       <div className='todo-item-buttons'>
-        {task.editOn ?
-          <span className='check' onClick={() => toggleEditOn(task.id)}>{check}</span> // TODO: Fix width/weight difference
-        : <span className='pencil' onClick={() => toggleEditOn(task.id)}>{pencil}</span>
+        {!task.editOn &&
+          <span className='pencil' onClick={() => toggleEditOn(task.id)}>{pencil}</span>
         }
         <span className='x-remove' onClick={() => removeTask(task.id)}>{x}</span>
       </div>

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -28,7 +28,7 @@ export default function TaskItem(props: TaskItemProps) {
       </div>
       <div className='todo-item-buttons'>
         {task.editOn ?
-          <span className='check'>{check}</span> // TODO: Fix width/weight difference
+          <span className='check' onClick={() => toggleEditOn(task.id)}>{check}</span> // TODO: Fix width/weight difference
         : <span className='pencil' onClick={() => toggleEditOn(task.id)}>{pencil}</span>
         }
         <span className='x-remove' onClick={() => removeTask(task.id)}>{x}</span>

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -9,18 +9,18 @@ const pencil = '\u270F';
 const check = '\u2713';
 
 export default function TaskItem(props: TaskItemProps) {
-  const { task, toggleComplete, removeTask } = props;
+  const { task, toggleComplete, removeTask, toggleEditOn, handleChange } = props;
 
   const getCompleteClass = (task: Task) => (task.completed ? 'complete' : '');
 
   return (
     <div className={`item-line ${getCompleteClass(task)}`}>
       <div className='todo-item'>
-        <span className='checkbox' onClick={() => {toggleComplete(task.id)}}>
+        <span className='checkbox' onClick={() => toggleComplete(task.id)}>
           {task.completed ? xBox : box}
         </span>
         {task.editOn ?
-          <input type='text' value={task.text}></input> // TODO: Fix size issue
+          <input type='text' value={task.text} onChange={handleChange(task.id)}/> // TODO: Fix size issue
         : <span className={`item-text ${getCompleteClass(task)}`}>
             {task.text}
           </span>
@@ -29,7 +29,7 @@ export default function TaskItem(props: TaskItemProps) {
       <div className='todo-item-buttons'>
         {task.editOn ?
           <span className='check'>{check}</span> // TODO: Fix width/weight difference
-        : <span className='pencil'>{pencil}</span>
+        : <span className='pencil' onClick={() => toggleEditOn(task.id)}>{pencil}</span>
         }
         <span className='x-remove' onClick={() => removeTask(task.id)}>{x}</span>
       </div>

--- a/src/components/Todo/TaskItemList.tsx
+++ b/src/components/Todo/TaskItemList.tsx
@@ -4,7 +4,7 @@ import TaskItem from './TaskItem';
 import { Task, TaskItemListProps } from './TodoList.interface';
 
 export default function TaskItemList(props: TaskItemListProps) {
-  const { tasks, toggleComplete, removeTask, toggleEditOn, handleChange } = props;
+  const { tasks, toggleComplete, removeTask, toggleEditOn, handleChange, handleSubmit } = props;
 
   return(
     <div id='task-list'>
@@ -18,6 +18,7 @@ export default function TaskItemList(props: TaskItemListProps) {
               removeTask={removeTask}
               toggleEditOn={toggleEditOn}
               handleChange={handleChange}
+              handleSubmit={handleSubmit}
             />
           );
         })

--- a/src/components/Todo/TaskItemList.tsx
+++ b/src/components/Todo/TaskItemList.tsx
@@ -4,7 +4,7 @@ import TaskItem from './TaskItem';
 import { Task, TaskItemListProps } from './TodoList.interface';
 
 export default function TaskItemList(props: TaskItemListProps) {
-  const { tasks, toggleComplete, removeTask } = props;
+  const { tasks, toggleComplete, removeTask, toggleEditOn, handleChange } = props;
 
   return(
     <div id='task-list'>
@@ -16,6 +16,8 @@ export default function TaskItemList(props: TaskItemListProps) {
               task={task} 
               toggleComplete={toggleComplete} 
               removeTask={removeTask}
+              toggleEditOn={toggleEditOn}
+              handleChange={handleChange}
             />
           );
         })

--- a/src/components/Todo/TodoList.interface.ts
+++ b/src/components/Todo/TodoList.interface.ts
@@ -13,6 +13,7 @@ interface TaskProps {
     removeTask: (id: Task['id']) => void;
     toggleEditOn: (id: Task['id']) => void;
     handleChange: (id: Task['id']) => React.ChangeEventHandler<HTMLInputElement>;
+    handleSubmit: (id: Task['id']) => React.FormEventHandler<HTMLFormElement>;
 }
 
 export interface TaskItemProps extends TaskProps {

--- a/src/components/Todo/TodoList.interface.ts
+++ b/src/components/Todo/TodoList.interface.ts
@@ -11,6 +11,8 @@ export interface Task {
 interface TaskProps {
     toggleComplete: (id: Task['id']) => void;
     removeTask: (id: Task['id']) => void;
+    toggleEditOn: (id: Task['id']) => void;
+    handleChange: (id: Task['id']) => React.ChangeEventHandler<HTMLInputElement>;
 }
 
 export interface TaskItemProps extends TaskProps {

--- a/src/components/Todo/TodoList.interface.ts
+++ b/src/components/Todo/TodoList.interface.ts
@@ -5,6 +5,7 @@ export interface Task {
     id: string;
     text: string;
     completed: boolean;
+    editOn: boolean;
 }
   
 interface TaskProps {

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -9,7 +9,7 @@ import SortToggle from './SortToggle'
 import { Task } from './TodoList.interface';
 
 const sampleTexts: string[] = ['TS conversion', 'Make lunch', 'Clean kitchen', 'Finish laundry'];
-const sampleTasks: Task[] = sampleTexts.map(text => ({ id: uuid(), text, completed: false }));
+const sampleTasks: Task[] = sampleTexts.map(text => ({ id: uuid(), text, completed: false, editOn: false }));
 
 
 export default function TodoList() {
@@ -58,7 +58,7 @@ export default function TodoList() {
 
   const handleSubmitTask = (evt: React.FormEvent<HTMLFormElement>) => {
     evt.preventDefault();
-    const newTask: Task = {id: uuid(), text: inputValue, completed: false}
+    const newTask: Task = {id: uuid(), text: inputValue, completed: false, editOn: false}
     const updatedTasks = sortOn ? sortTask(newTask, [...tasks]) : [...tasks, newTask]
     setTasks(updatedTasks)
   }

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -48,7 +48,7 @@ export default function TodoList() {
   const removeTask = (id: Task['id']) => {
     setTasks(tasks.filter(task => task.id !== id));
   }
-  
+
   const toggleEditTask = (id: Task['id']) => {
     setTasks(tasks.map(task => (
       task.id === id
@@ -63,6 +63,11 @@ export default function TodoList() {
         ? {...task, text: evt.target.value}
         : task
     )));
+  }
+
+  const handleSubmitEdit = (id: Task['id']) => (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    toggleEditTask(id);
   }
 
 
@@ -128,6 +133,7 @@ export default function TodoList() {
           removeTask={removeTask}
           toggleEditOn={toggleEditTask}
           handleChange={handleChangeTask}
+          handleSubmit={handleSubmitEdit}
         />
         <TaskInput 
           value={inputValue}

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -48,6 +48,22 @@ export default function TodoList() {
   const removeTask = (id: Task['id']) => {
     setTasks(tasks.filter(task => task.id !== id));
   }
+  
+  const toggleEditTask = (id: Task['id']) => {
+    setTasks(tasks.map(task => (
+      task.id === id
+        ? {...task, editOn: !task.editOn}
+        : task
+    )));
+  }
+
+  const handleChangeTask = (id: Task['id']) => (evt: React.ChangeEvent<HTMLInputElement>) => {
+    setTasks(tasks.map(task => (
+      task.id === id
+        ? {...task, text: evt.target.value}
+        : task
+    )));
+  }
 
 
   // Input state functions
@@ -110,6 +126,8 @@ export default function TodoList() {
           tasks={tasks}
           toggleComplete={toggleComplete}
           removeTask={removeTask}
+          toggleEditOn={toggleEditTask}
+          handleChange={handleChangeTask}
         />
         <TaskInput 
           value={inputValue}

--- a/src/index.css
+++ b/src/index.css
@@ -137,3 +137,18 @@ button, input {
 .plus {
   font-size: 120%;
 }
+
+/* Edit task */
+.todo-item-buttons {
+  display: flex;
+  align-items: center;
+}
+
+.pencil {
+  transform: scaleX(-1);
+  font-size: 120%;
+}
+
+.x-remove {
+  padding-left: 1rem;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,7 @@ button, input {
 .todo-item {
   display: flex;
   align-items: center;
-  padding-right: 2rem;
+  padding-right: 1rem;
 }
 
 .checkbox {
@@ -160,4 +160,5 @@ button, input {
   border: none;
   padding: 0;
   outline: none;
+  color: inherit;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,11 @@ button, input {
   flex-wrap: wrap;
 }
 
+.list-buttons {
+  margin-bottom: 1rem;
+}
+
+/* Task items */
 .item-line {
   display: flex;
   flex-flow: row nowrap;
@@ -49,7 +54,7 @@ button, input {
 }
 
 .checkbox {
-  padding-right: 1rem;
+  margin-right: 0.25rem;
   font-size: 150%;
 }
 
@@ -61,8 +66,51 @@ button, input {
   text-decoration: line-through;
 }
 
-.list-buttons {
-  margin-bottom: 1rem;
+/* Edit task */
+.todo-item-buttons {
+  display: flex;
+  align-items: center;
+}
+
+.pencil {
+  transform: scaleX(-1);
+  font-size: 120%;
+}
+
+.x-remove {
+  margin-left: 0.25rem;
+}
+
+.pencil, .x-remove, .checkbox, .no-pencil {
+  width: 29.5px;
+  height: 29.5px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+}
+
+.pencil:hover, .x-remove:hover, .checkbox:hover {
+  background-color: #EFEFEF;
+}
+
+.pencil:active, .x-remove:active, .checkbox:active {
+  background-color: #D2D2D2;
+}
+
+.item-line input, .item-line input:focus {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  border: none;
+  border-radius: 0.9em;
+  padding: 0 0.5rem;
+  outline: none;
+  color: inherit;
+}
+
+.item-line.edit input:focus {
+  background-color: #EFEFEF;
 }
 
 /* Sort toggle switch */
@@ -136,29 +184,4 @@ button, input {
 
 .plus {
   font-size: 120%;
-}
-
-/* Edit task */
-.todo-item-buttons {
-  display: flex;
-  align-items: center;
-}
-
-.pencil {
-  transform: scaleX(-1);
-  font-size: 120%;
-}
-
-.x-remove {
-  padding-left: 1rem;
-}
-
-.item-line input, .item-line input:focus {
-  margin: 0;
-  font-family: inherit;
-  font-size: inherit;
-  border: none;
-  padding: 0;
-  outline: none;
-  color: inherit;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -152,3 +152,12 @@ button, input {
 .x-remove {
   padding-left: 1rem;
 }
+
+.item-line input, .item-line input:focus {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  border: none;
+  padding: 0;
+  outline: none;
+}


### PR DESCRIPTION
- `TaskItem` text state now editable through inline input, pencil Unicode icon triggers `editOn` state, focus to the specific `editOn` task input provided with `useRef` and `useEffect` hooks
- State update `toggleEditTask`, and event handler `handleChangeTask` and `handleSubmitEdit` functions passed down as props from `TodoList`, `TaskProps` interface updated
- Icons styled with `:hover` and `:active` backgrounds, edit inputs styled with `:focus` background, spacing tweaked, reordered CSS for better organization