### PR TITLE
Inline new task

### DIFF
--- a/src/components/Todo/TaskInput.tsx
+++ b/src/components/Todo/TaskInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 
 import { TaskInputProps } from './TodoList.interface';
 
@@ -7,38 +7,54 @@ const pencil = '\u270F';
 
 export default function TaskInput(props: TaskInputProps) {
   const { text, editOn } = props.newTaskInput;
-  const { toggleEditOn, handleChange, handleSubmit } = props;
+  const { toggleEditOn, handleChange, addNewTask } = props;
 
   const activeInput = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    activeInput.current?.focus()
-  }, [activeInput, editOn])
+  const form = useRef<HTMLFormElement>(null);
 
   const getEditOnClass = () => editOn ? 'edit' : '';
 
+  const handlePencilClick = () => {
+    toggleEditOn();
+    activeInput.current!.focus();
+  }
+
+  const handleSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    activeInput.current!.blur()
+    if (text.length > 0) {  // TODO: Strip text
+      addNewTask()
+    }
+  }
+
+  const handleBlur = (evt: React.FocusEvent<HTMLInputElement>) => {
+    if (text.length > 0) {  // TODO: Strip text
+      form.current!.requestSubmit()
+    } else {
+      toggleEditOn()
+    }
+  }
+
   return (
-  <div className={`item-line ${getEditOnClass()}`}>
+  <form className={`item-line ${getEditOnClass()}`} ref={form} onSubmit={handleSubmit}>
     <div className='todo-item'>
       <span className='checkbox'>
         {box}
       </span>
-      <form onSubmit={handleSubmit}>
-        <input
-          type='text'
-          value={text}
-          onChange={handleChange}
-          ref={activeInput}
-          className={`item-text`}
-          style={{width: text.length + 2 + 'ch'}} // TODO: move to css component library
-          onBlur={() => editOn && toggleEditOn()}
-        />
-      </form>
+      <input
+        type='text'
+        value={text}
+        onChange={handleChange}
+        ref={activeInput}
+        className={`item-text`}
+        style={{width: text.length + 2 + 'ch'}} // TODO: move to css component library
+        onBlur={handleBlur}
+      />
     </div>
     <div className='todo-item-buttons'>
-      <span className='pencil' onClick={toggleEditOn}>{pencil}</span>
+      {!editOn && <span className='pencil' onClick={handlePencilClick}>{pencil}</span>}
       <span className='no-pencil'></span>
     </div>
-  </div>
+  </form>
   );
 }

--- a/src/components/Todo/TaskInput.tsx
+++ b/src/components/Todo/TaskInput.tsx
@@ -4,6 +4,7 @@ import { TaskInputProps } from './TodoList.interface';
 
 const box = '\u2610';
 const pencil = '\u270F';
+const plus = '\uFF0B';
 
 export default function TaskInput(props: TaskInputProps) {
   const { text, editOn } = props.newTaskInput;
@@ -35,8 +36,8 @@ export default function TaskInput(props: TaskInputProps) {
     }
   }
 
-  return (
-  <form className={`item-line ${getEditOnClass()}`} ref={form} onSubmit={handleSubmit}>
+  return ( // TODO: fix className whitespace
+  <form className={`item-line task-input ${getEditOnClass()}`} ref={form} onSubmit={handleSubmit}>
     <div className='todo-item'>
       <span className='checkbox'>
         {box}
@@ -54,6 +55,7 @@ export default function TaskInput(props: TaskInputProps) {
     <div className='todo-item-buttons'>
       {!editOn && <span className='pencil' onClick={handlePencilClick}>{pencil}</span>}
       <span className='no-pencil'></span>
+      {editOn && text.length > 0 && <span className='plus'>{plus}</span>}
     </div>
   </form>
   );

--- a/src/components/Todo/TaskInput.tsx
+++ b/src/components/Todo/TaskInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 
 import { TaskInputProps } from './TodoList.interface';
 
@@ -6,19 +6,16 @@ const box = '\u2610';
 const pencil = '\u270F';
 
 export default function TaskInput(props: TaskInputProps) {
-  const { value, handleChange, handleSubmit } = props;
-
-  const [inputFocus, setInputFocus] = useState(false);
+  const { text, editOn } = props.newTaskInput;
+  const { toggleEditOn, handleChange, handleSubmit } = props;
 
   const activeInput = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     activeInput.current?.focus()
-  }, [activeInput, inputFocus])
+  }, [activeInput, editOn])
 
-  const toggleInputFocus = () => setInputFocus(!inputFocus);
-
-  const getEditOnClass = () => inputFocus ? 'edit' : '';
+  const getEditOnClass = () => editOn ? 'edit' : '';
 
   return (
   <div className={`item-line ${getEditOnClass()}`}>
@@ -29,17 +26,17 @@ export default function TaskInput(props: TaskInputProps) {
       <form onSubmit={handleSubmit}>
         <input
           type='text'
-          value={value}
+          value={text}
           onChange={handleChange}
           ref={activeInput}
           className={`item-text`}
-          style={{width: value.length + 2 + 'ch'}} // TODO: move to css component library
-          onBlur={() => inputFocus && toggleInputFocus()}
+          style={{width: text.length + 2 + 'ch'}} // TODO: move to css component library
+          onBlur={() => editOn && toggleEditOn()}
         />
       </form>
     </div>
     <div className='todo-item-buttons'>
-      <span className='pencil' onClick={toggleInputFocus}>{pencil}</span>
+      <span className='pencil' onClick={toggleEditOn}>{pencil}</span>
       <span className='no-pencil'></span>
     </div>
   </div>

--- a/src/components/Todo/TaskInput.tsx
+++ b/src/components/Todo/TaskInput.tsx
@@ -37,26 +37,26 @@ export default function TaskInput(props: TaskInputProps) {
   }
 
   return ( // TODO: fix className whitespace
-  <form className={`item-line task-input ${getEditOnClass()}`} ref={form} onSubmit={handleSubmit}>
-    <div className='todo-item'>
-      <span className='checkbox'>
-        {box}
-      </span>
-      <input
-        type='text'
-        value={text}
-        onChange={handleChange}
-        ref={activeInput}
-        className={`item-text`}
-        style={{width: text.length + 2 + 'ch'}} // TODO: move to css component library
-        onBlur={handleBlur}
-      />
-    </div>
-    <div className='todo-item-buttons'>
-      {!editOn && <span className='pencil' onClick={handlePencilClick}>{pencil}</span>}
-      <span className='no-pencil'></span>
-      {editOn && text.length > 0 && <span className='plus'>{plus}</span>}
-    </div>
-  </form>
+    <form className={`item-line task-input ${getEditOnClass()}`} ref={form} onSubmit={handleSubmit}>
+      <div className='todo-item'>
+        <span className='checkbox'>
+          {box}
+        </span>
+        <input
+          type='text'
+          value={text}
+          onChange={handleChange}
+          ref={activeInput}
+          className={`item-text`}
+          style={{width: text.length + 2 + 'ch'}} // TODO: move to css component library
+          onBlur={handleBlur}
+        />
+      </div>
+      <div className='todo-item-buttons'>
+        {!editOn && <span className='pencil' onClick={handlePencilClick}>{pencil}</span>}
+        <span className='no-icon'></span>
+        {editOn && text.length > 0 && <span className='plus'>{plus}</span>}
+      </div>
+    </form>
   );
 }

--- a/src/components/Todo/TaskInput.tsx
+++ b/src/components/Todo/TaskInput.tsx
@@ -1,28 +1,47 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
 import { TaskInputProps } from './TodoList.interface';
 
-const x = '\u2715';
-const plus = '\uFF0B';
+const box = '\u2610';
+const pencil = '\u270F';
 
 export default function TaskInput(props: TaskInputProps) {
-  const { value, isOpen, toggleOpen, handleChange, handleSubmit } = props;
+  const { value, handleChange, handleSubmit } = props;
+
+  const [inputFocus, setInputFocus] = useState(false);
+
+  const activeInput = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    activeInput.current?.focus()
+  }, [activeInput, inputFocus])
+
+  const toggleInputFocus = () => setInputFocus(!inputFocus);
+
+  const getEditOnClass = () => inputFocus ? 'edit' : '';
 
   return (
-    <>
-      {isOpen ? 
-        <form className='add-item-line open' onSubmit={handleSubmit}>
-          <div className='input-line'>
-            <input type='text' value={value} onChange={handleChange}/>
-            <button type='submit'>Add</button>
-          </div>
-          <span onClick={toggleOpen}>{x}</span>
-        </form>
-      : <div className='add-item-line' onClick={toggleOpen}>
-          <span className='plus'>{plus}</span>
-          <button>Add Task</button>
-        </div>  
-      }
-    </>
+  <div className={`item-line ${getEditOnClass()}`}>
+    <div className='todo-item'>
+      <span className='checkbox'>
+        {box}
+      </span>
+      <form onSubmit={handleSubmit}>
+        <input
+          type='text'
+          value={value}
+          onChange={handleChange}
+          ref={activeInput}
+          className={`item-text`}
+          style={{width: value.length + 2 + 'ch'}} // TODO: move to css component library
+          onBlur={() => inputFocus && toggleInputFocus()}
+        />
+      </form>
+    </div>
+    <div className='todo-item-buttons'>
+      <span className='pencil' onClick={toggleInputFocus}>{pencil}</span>
+      <span className='no-pencil'></span>
+    </div>
+  </div>
   );
 }

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -49,7 +49,7 @@ export default function TaskItem(props: TaskItemProps) {
       </div>
       <div className='todo-item-buttons'>
         {task.editOn ?
-          <span className='no-pencil'></span>
+          <span className='no-icon'></span>
         : <span className='pencil' onClick={toggleFocus}>{pencil}</span>
         }
         <span className='x-remove' onClick={() => removeTask(task.id)}>{x}</span>

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 
-import { Task, TaskItemProps } from './TodoList.interface';
+import { TaskItemProps } from './TodoList.interface';
 
 const box = '\u2610';
 const xBox = '\u2612';

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 
 import { Task, TaskItemProps } from './TodoList.interface';
 
@@ -8,45 +8,52 @@ const x = '\u2715';
 const pencil = '\u270F';
 
 export default function TaskItem(props: TaskItemProps) {
-  const { task, toggleComplete, removeTask, toggleEditOn, handleChange, handleSubmit } = props;
+  const { task, toggleComplete, removeTask, toggleEditOn, handleChange } = props;
 
-  // TODO: move to higher component, only one possible input open at once
   const activeInput = useRef<HTMLInputElement>(null);
-  
-  useEffect(() => {
-    activeInput.current?.focus()
-  }, [activeInput, task.editOn])
-  
-  const getCompleteClass = (task: Task) => (task.completed ? 'complete' : '');
 
-  const getEditOnClass = (task: Task) => (task.editOn ? 'edit' : '');
+  const getCompleteClass = () => (task.completed ? 'complete' : '');
 
-  return (
-    <div className={`item-line ${getCompleteClass(task)} ${getEditOnClass(task)}`}>
+  const getEditOnClass = () => (task.editOn ? 'edit' : '');
+
+  const toggleFocus = () => {
+    if (task.editOn) {
+      activeInput.current!.blur()
+    } else {
+      activeInput.current!.focus()
+    }
+    toggleEditOn(task.id)
+  }
+
+  const handleSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    toggleFocus();
+  }
+
+  return ( // TODO: fix className whitespace
+    <form className={`item-line ${getCompleteClass} ${getEditOnClass}`} onSubmit={handleSubmit}>
       <div className='todo-item'>
         <span className='checkbox' onClick={() => toggleComplete(task.id)}>
           {task.completed ? xBox : box}
         </span>
-        <form onSubmit={handleSubmit(task.id)}>
-          <input
-            type='text'
-            value={task.text}
-            onChange={handleChange(task.id)}
-            ref={activeInput}
-            className={`item-text ${getCompleteClass(task)}`}
-            style={{width: task.text.length + 2 + 'ch'}} // TODO: move to css component library
-            readOnly={!task.editOn}
-            onBlur={() => task.editOn && toggleEditOn(task.id)}
-          />
-        </form>
+        <input
+          type='text'
+          value={task.text}
+          onChange={handleChange(task.id)}
+          ref={activeInput}
+          className={`item-text ${getCompleteClass}`}
+          style={{width: task.text.length + 2 + 'ch'}} // TODO: move to css component library
+          readOnly={!task.editOn}
+          onBlur={toggleFocus}
+        />
       </div>
       <div className='todo-item-buttons'>
         {task.editOn ?
           <span className='no-pencil'></span>
-        : <span className='pencil' onClick={() => toggleEditOn(task.id)}>{pencil}</span>
+        : <span className='pencil' onClick={toggleFocus}>{pencil}</span>
         }
         <span className='x-remove' onClick={() => removeTask(task.id)}>{x}</span>
       </div>
-    </div>
+    </form>
   );
 }

--- a/src/components/Todo/TaskItem.tsx
+++ b/src/components/Todo/TaskItem.tsx
@@ -31,7 +31,7 @@ export default function TaskItem(props: TaskItemProps) {
   }
 
   return ( // TODO: fix className whitespace
-    <form className={`item-line ${getCompleteClass} ${getEditOnClass}`} onSubmit={handleSubmit}>
+    <form className={`item-line ${getCompleteClass()} ${getEditOnClass()}`} onSubmit={handleSubmit}>
       <div className='todo-item'>
         <span className='checkbox' onClick={() => toggleComplete(task.id)}>
           {task.completed ? xBox : box}
@@ -41,7 +41,7 @@ export default function TaskItem(props: TaskItemProps) {
           value={task.text}
           onChange={handleChange(task.id)}
           ref={activeInput}
-          className={`item-text ${getCompleteClass}`}
+          className={`item-text ${getCompleteClass()}`}
           style={{width: task.text.length + 2 + 'ch'}} // TODO: move to css component library
           readOnly={!task.editOn}
           onBlur={toggleFocus}

--- a/src/components/Todo/TaskItemList.tsx
+++ b/src/components/Todo/TaskItemList.tsx
@@ -4,7 +4,7 @@ import TaskItem from './TaskItem';
 import { Task, TaskItemListProps } from './TodoList.interface';
 
 export default function TaskItemList(props: TaskItemListProps) {
-  const { tasks, toggleComplete, removeTask, toggleEditOn, handleChange, handleSubmit } = props;
+  const { tasks, toggleComplete, removeTask, toggleEditOn, handleChange } = props;
 
   return(
     <div id='task-list'>
@@ -18,7 +18,6 @@ export default function TaskItemList(props: TaskItemListProps) {
               removeTask={removeTask}
               toggleEditOn={toggleEditOn}
               handleChange={handleChange}
-              handleSubmit={handleSubmit}
             />
           );
         })

--- a/src/components/Todo/TodoList.interface.ts
+++ b/src/components/Todo/TodoList.interface.ts
@@ -15,7 +15,6 @@ interface TaskProps {
     removeTask: (id: Task['id']) => void;
     toggleEditOn: (id: Task['id']) => void;
     handleChange: (id: Task['id']) => React.ChangeEventHandler<HTMLInputElement>;
-    handleSubmit: (id: Task['id']) => React.FormEventHandler<HTMLFormElement>;
 }
 
 export interface TaskItemProps extends TaskProps {

--- a/src/components/Todo/TodoList.interface.ts
+++ b/src/components/Todo/TodoList.interface.ts
@@ -30,7 +30,7 @@ export interface TaskInputProps {
     newTaskInput: NewTask;
     toggleEditOn: () => void;
     handleChange: React.ChangeEventHandler<HTMLInputElement>;
-    handleSubmit: React.FormEventHandler<HTMLFormElement>;
+    addNewTask: () => void;
 }
 
 export interface TaskButtonProps {

--- a/src/components/Todo/TodoList.interface.ts
+++ b/src/components/Todo/TodoList.interface.ts
@@ -26,8 +26,6 @@ export interface TaskItemListProps extends TaskProps {
 
 export interface TaskInputProps {
     value: string;
-    isOpen: boolean;
-    toggleOpen: () => void;
     handleChange: React.ChangeEventHandler<HTMLInputElement>;
     handleSubmit: React.FormEventHandler<HTMLFormElement>;
 }

--- a/src/components/Todo/TodoList.interface.ts
+++ b/src/components/Todo/TodoList.interface.ts
@@ -1,11 +1,13 @@
 import React from "react";
 
-
-export interface Task {
-    id: string;
+export interface NewTask {
     text: string;
-    completed: boolean;
     editOn: boolean;
+}
+
+export interface Task extends NewTask {
+    id: string;
+    completed: boolean;
 }
   
 interface TaskProps {
@@ -25,7 +27,8 @@ export interface TaskItemListProps extends TaskProps {
 }
 
 export interface TaskInputProps {
-    value: string;
+    newTaskInput: NewTask;
+    toggleEditOn: () => void;
     handleChange: React.ChangeEventHandler<HTMLInputElement>;
     handleSubmit: React.FormEventHandler<HTMLFormElement>;
 }

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -6,15 +6,16 @@ import TaskItemList from './TaskItemList';
 import TaskInput from './TaskInput';
 import SortToggle from './SortToggle'
 
-import { Task } from './TodoList.interface';
+import { Task, NewTask } from './TodoList.interface';
 
 const sampleTexts: string[] = ['TS conversion', 'Make lunch', 'Clean kitchen', 'Finish laundry'];
 const sampleTasks: Task[] = sampleTexts.map(text => ({ id: uuid(), text, completed: false, editOn: false }));
+const initialNewTaskInput: NewTask = { text: '', editOn: false }
 
 
 export default function TodoList() {
   const [tasks, setTasks] = useState(sampleTasks);
-  const [inputValue, setInputValue] = useState('');
+  const [newTaskInput, setNewTaskInput] = useState(initialNewTaskInput);
   const [sortOn, setSortOn] = useState(false);
 
   // Task State functions
@@ -71,17 +72,21 @@ export default function TodoList() {
 
 
   // Input state functions
+  const toggleEditInput = () => {
+    setNewTaskInput({...newTaskInput, editOn: !newTaskInput.editOn})
+  }
+
   const changeInput = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = evt.target;
-    setInputValue(value);
+    setNewTaskInput({...newTaskInput, text: value});
   }
 
   const handleSubmitTask = (evt: React.FormEvent<HTMLFormElement>) => {
     evt.preventDefault();
-    const newTask: Task = {id: uuid(), text: inputValue, completed: false, editOn: false}
+    const newTask: Task = {id: uuid(), text: newTaskInput.text, completed: false, editOn: false}
     const updatedTasks = sortOn ? sortTask(newTask, [...tasks]) : [...tasks, newTask]
     setTasks(updatedTasks)
-    setInputValue('')
+    setNewTaskInput(initialNewTaskInput)
   }
 
 
@@ -132,7 +137,8 @@ export default function TodoList() {
           handleSubmit={handleSubmitEdit}
         />
         <TaskInput 
-          value={inputValue}
+          newTaskInput={newTaskInput}
+          toggleEditOn={toggleEditInput}
           handleChange={changeInput}
           handleSubmit={handleSubmitTask}
         />

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -16,7 +16,6 @@ export default function TodoList() {
   const [tasks, setTasks] = useState(sampleTasks);
   const [inputValue, setInputValue] = useState('');
   const [sortOn, setSortOn] = useState(false);
-  const [inputOpen, setInputOpen] = useState(false);
 
   // Task State functions
   const checkAllTasks = () => {
@@ -82,10 +81,7 @@ export default function TodoList() {
     const newTask: Task = {id: uuid(), text: inputValue, completed: false, editOn: false}
     const updatedTasks = sortOn ? sortTask(newTask, [...tasks]) : [...tasks, newTask]
     setTasks(updatedTasks)
-  }
-
-  const toggleInputOpen = () => {
-    setInputOpen(!inputOpen)
+    setInputValue('')
   }
 
 
@@ -137,8 +133,6 @@ export default function TodoList() {
         />
         <TaskInput 
           value={inputValue}
-          isOpen={inputOpen}
-          toggleOpen={toggleInputOpen}
           handleChange={changeInput}
           handleSubmit={handleSubmitTask}
         />

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -18,6 +18,7 @@ export default function TodoList() {
   const [newTaskInput, setNewTaskInput] = useState(initialNewTaskInput);
   const [sortOn, setSortOn] = useState(false);
 
+
   // Task State functions
   const checkAllTasks = () => {
     setTasks(tasks.map(task => ({...task, completed: true})));
@@ -65,11 +66,6 @@ export default function TodoList() {
     )));
   }
 
-  const handleSubmitEdit = (id: Task['id']) => (evt: React.FormEvent<HTMLFormElement>) => {
-    evt.preventDefault();
-    toggleEditTask(id);
-  }
-
 
   // Input state functions
   const toggleEditInput = () => {
@@ -113,12 +109,13 @@ export default function TodoList() {
     }
   }
 
+
   return (
     <div className='widget-todo container'>
       <h2>To-do List</h2>
       <SortToggle 
-        sortOn = {sortOn}
-        toggleSort = {toggleSort}
+        sortOn={sortOn}
+        toggleSort={toggleSort}
       />
       <TaskButtons 
         tasks={tasks}
@@ -133,7 +130,6 @@ export default function TodoList() {
           removeTask={removeTask}
           toggleEditOn={toggleEditTask}
           handleChange={handleChangeTask}
-          handleSubmit={handleSubmitEdit}
         />
         <TaskInput 
           newTaskInput={newTaskInput}

--- a/src/components/Todo/TodoList.tsx
+++ b/src/components/Todo/TodoList.tsx
@@ -76,13 +76,12 @@ export default function TodoList() {
     setNewTaskInput({...newTaskInput, editOn: !newTaskInput.editOn})
   }
 
-  const changeInput = (evt: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeInput = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = evt.target;
     setNewTaskInput({...newTaskInput, text: value});
   }
 
-  const handleSubmitTask = (evt: React.FormEvent<HTMLFormElement>) => {
-    evt.preventDefault();
+  const addNewTask = () => {
     const newTask: Task = {id: uuid(), text: newTaskInput.text, completed: false, editOn: false}
     const updatedTasks = sortOn ? sortTask(newTask, [...tasks]) : [...tasks, newTask]
     setTasks(updatedTasks)
@@ -139,8 +138,8 @@ export default function TodoList() {
         <TaskInput 
           newTaskInput={newTaskInput}
           toggleEditOn={toggleEditInput}
-          handleChange={changeInput}
-          handleSubmit={handleSubmitTask}
+          handleChange={handleChangeInput}
+          addNewTask={addNewTask}
         />
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -75,13 +75,10 @@ button, input {
 .pencil {
   transform: scaleX(-1);
   font-size: 120%;
+  margin-right: 0.25rem;
 }
 
-.x-remove {
-  margin-left: 0.25rem;
-}
-
-.pencil, .x-remove, .checkbox, .no-pencil {
+.pencil, .x-remove, .checkbox, .no-pencil, .plus {
   width: 29.5px;
   height: 29.5px;
   display: inline-flex;
@@ -90,11 +87,11 @@ button, input {
   border-radius: 50%;
 }
 
-.pencil:hover, .x-remove:hover, .checkbox:hover {
+.pencil:hover, .x-remove:hover, .item-line:not(.task-input) .checkbox:hover, .plus:hover {
   background-color: #EFEFEF;
 }
 
-.pencil:active, .x-remove:active, .checkbox:active {
+.pencil:active, .x-remove:active, .item-line:not(.task-input) .checkbox:active, .plus:active {
   background-color: #D2D2D2;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -78,7 +78,7 @@ button, input {
   margin-right: 0.25rem;
 }
 
-.pencil, .x-remove, .checkbox, .no-pencil, .plus {
+.pencil, .x-remove, .checkbox, .no-icon, .plus {
   width: 29.5px;
   height: 29.5px;
   display: inline-flex;

--- a/src/index.css
+++ b/src/index.css
@@ -160,25 +160,15 @@ button, input {
   padding-right: 0.5rem;
 }
 
-/* Input component open/close */
-.add-item-line {
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: center;
-  align-items: center;
-  margin-top: 1rem;
-}
-
-.input-line, .input-line input {
-  width: 100%;
-}
-
-.add-item-line.open .input-line {
-  display: flex;
-  align-items: center;
-  padding-right: 0.5rem;
-}
-
 .plus {
   font-size: 120%;
+}
+
+#task-list {
+  border-bottom: 1px solid gray;
+  padding-bottom: 0.25rem;
+}
+
+.task-input {
+  padding-top: 0.25rem;
 }


### PR DESCRIPTION
- `TaskInput` now has similar structure/style as `TaskItem` and appears inline with task list at the bottom
- `TaskInput state simplified to `editOn` and `text` fields within single state `newTaskInput`
- `TaskInput` has separate ``handleSubmit` and `handleBlur` functions that trigger the other event for consistent behavior on either `blur` or `submit` events
- `TaskInput` and `TaskItem` contain own `handleSubmit` functions instead of through props, calling state change functions passed as props from `TodoList`
- `TaskItem` no longer changes focus with `useEffect`, instead has a `toggleFocus` function